### PR TITLE
Use atomic tmp-then-rename writes in cache

### DIFF
--- a/tactless.c
+++ b/tactless.c
@@ -251,8 +251,7 @@ static int writeall(const char *filename, const byte *text, size_t size) {
   if (!tmpname) {
     return 0;
   }
-  memcpy(tmpname, filename, fnlen);
-  memcpy(tmpname + fnlen, ".tmp", 5);
+  snprintf(tmpname, fnlen + 5, "%s.tmp", filename);
   FILE *f = fopen(tmpname, "w");
   if (!f) {
     free(tmpname);

--- a/tactless.c
+++ b/tactless.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include <zlib.h>
 
 typedef unsigned char byte;
@@ -246,17 +247,35 @@ byte *tactless_readfile(const char *filename, size_t *size) {
 }
 
 static int writeall(const char *filename, const byte *text, size_t size) {
-  FILE *f = fopen(filename, "w");
+  size_t fnlen = strlen(filename);
+  char *tmpname = malloc(fnlen + 5);
+  if (!tmpname) {
+    return 0;
+  }
+  memcpy(tmpname, filename, fnlen);
+  memcpy(tmpname + fnlen, ".tmp", 5);
+  FILE *f = fopen(tmpname, "w");
   if (!f) {
+    free(tmpname);
     return 0;
   }
   if (fwrite(text, size, 1, f) != 1) {
     fclose(f);
+    unlink(tmpname);
+    free(tmpname);
     return 0;
   }
   if (fclose(f) != 0) {
+    unlink(tmpname);
+    free(tmpname);
     return 0;
   }
+  if (rename(tmpname, filename) != 0) {
+    unlink(tmpname);
+    free(tmpname);
+    return 0;
+  }
+  free(tmpname);
   return 1;
 }
 

--- a/tactless.c
+++ b/tactless.c
@@ -6,7 +6,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <zlib.h>
 
 typedef unsigned char byte;
@@ -261,17 +260,17 @@ static int writeall(const char *filename, const byte *text, size_t size) {
   }
   if (fwrite(text, size, 1, f) != 1) {
     fclose(f);
-    unlink(tmpname);
+    remove(tmpname);
     free(tmpname);
     return 0;
   }
   if (fclose(f) != 0) {
-    unlink(tmpname);
+    remove(tmpname);
     free(tmpname);
     return 0;
   }
   if (rename(tmpname, filename) != 0) {
-    unlink(tmpname);
+    remove(tmpname);
     free(tmpname);
     return 0;
   }


### PR DESCRIPTION
## Summary

- Modify `writeall()` in `tactless.c` to write cache data to a `.tmp` file first, then atomically `rename()` it to the final path
- On any failure (open, write, close, rename), the `.tmp` file is cleaned up with `remove()`

This ensures readers never observe a partially-written cache file.