### PR TITLE
Replace atol/atoi/sscanf with strtol/strtoul for clang-tidy compliance

### DIFF
--- a/main.c
+++ b/main.c
@@ -82,8 +82,15 @@ static int fdid(int argc, char **argv) {
     fputs("error opening tactless\n", stderr);
     return 0;
   }
+  char *endptr;
+  int32_t fdid_val = (int32_t)strtol(argv[1], &endptr, 10);
+  if (endptr == argv[1]) {
+    fputs("invalid fdid\n", stderr);
+    tactless_close(t);
+    return 0;
+  }
   size_t size;
-  unsigned char *data = tactless_get_fdid(t, atoi(argv[1]), &size);
+  unsigned char *data = tactless_get_fdid(t, fdid_val, &size);
   if (!data) {
     tactless_close(t);
     return 0;

--- a/tactless.c
+++ b/tactless.c
@@ -22,8 +22,9 @@ static size_t collect_header_callback(char *data, size_t size, size_t nitems,
   if (realsize >= 16 && !memcmp(data, "Content-Length: ", 16)) {
     memcpy(data, data + 16, realsize - 16);
     data[realsize - 16] = '\0';
-    long length = atol(data);
-    if (length == 0) {
+    char *endptr;
+    long length = strtol(data, &endptr, 10);
+    if (endptr == data || length <= 0) {
       return 0;
     }
     struct collect_buffer *buffer = cbarg;
@@ -133,12 +134,14 @@ static int parse_hash(const char *s, char delim, byte *hash) {
   if (end - s != 32) {
     return 0;
   }
-  unsigned int x;
   for (; s != end; s += 2, ++hash) {
-    if (sscanf(s, "%02x", &x) != 1) {
+    char hex[3] = {s[0], s[1], '\0'};
+    char *endptr;
+    byte val = (byte)strtoul(hex, &endptr, 16);
+    if (endptr != hex + 2) {
       return 0;
     }
-    *hash = x;
+    *hash = val;
   }
   return 1;
 }
@@ -171,8 +174,21 @@ static int parse_versions(const char *s, struct versions *versions) {
   if (!s) {
     return 0;
   }
-  int a, b, c, d;
-  if (sscanf(s, "|%d.%d.%d.%d|", &a, &b, &c, &d) != 4) {
+  char *endptr;
+  int a = (int)strtol(s + 1, &endptr, 10);
+  if (endptr == s + 1 || *endptr != '.') {
+    return 0;
+  }
+  int b = (int)strtol(endptr + 1, &endptr, 10);
+  if (*endptr != '.') {
+    return 0;
+  }
+  int c = (int)strtol(endptr + 1, &endptr, 10);
+  if (*endptr != '.') {
+    return 0;
+  }
+  int d = (int)strtol(endptr + 1, &endptr, 10);
+  if (*endptr != '|') {
     return 0;
   }
   versions->major = a;


### PR DESCRIPTION
## Summary

- Replace `atol()` with `strtol()` in `collect_header_callback` for Content-Length parsing
- Replace `sscanf("%02x", ...)` with a `char[3]` buffer + `strtoul(..., 16)` in `parse_hash`
- Replace `sscanf("|%d.%d.%d.%d|", ...)` with chained `strtol` calls in `parse_versions`
- Replace `atoi()` with `strtol()` in the `fdid` command for FDID argument parsing

All changes allow callers to detect parse failures via `endptr`, satisfying the clang-tidy `bugprone-unchecked-string-to-number-conversion` check.